### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
 		"type": "git",
 		"url": "https://github.com/myfreeweb/nextcss.git"
 	},
-	"license": [{
-		"type": "Apache-2.0",
-		"url": "https://github.com/myfreeweb/nextcss/blob/master/COPYING"
-	}],
+	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/myfreeweb/nextcss/issues"
 	},


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license